### PR TITLE
create : 커뮤니티 페이지 게시글 최신순/인기순 정렬(카테고리 선택 포함)

### DIFF
--- a/js/main/api.js
+++ b/js/main/api.js
@@ -50,8 +50,8 @@ async function get_hobby() {
 }
 
 // 게시글 전체 목록 API
-async function get_articles() {
-    const response = await fetch(`${back_end_url}/articles/`, {
+async function get_articles(sort, category_id) {
+    const response = await fetch(`${back_end_url}/articles/?sort=${sort}&category=${category_id}`, {
         method: "GET",
     })
     return response
@@ -65,8 +65,8 @@ async function get_lank_articles() {
 }
 
 // 카테고리 선택 시 해당 카테고리 게시글 리스트 API
-async function get_select_articles(category_id) {
-    const response = await fetch(`${back_end_url}/articles/?category=${category_id}`, {
+async function get_select_articles(category_id, sort) {
+    const response = await fetch(`${back_end_url}/articles/?category=${category_id}&sort=${sort}`, {
         method: "GET",
     })
     return response

--- a/js/main/community.js
+++ b/js/main/community.js
@@ -4,11 +4,14 @@ window.onload = async() => {
 }
 
 // 전체 카테고리의 게시글 목록
-async function article_list() {
-    const response = await get_articles()
+async function article_list(sort, category_id) {
+    const response = await get_articles(sort, category_id)
     const response_json = await response.json()
     const data = response_json['results']
     
+    const article_list = document.getElementById('article_list')
+    article_list.innerHTML = ''
+
     for (let i = 0; i < data.length; i++) {
         let id = data[i]['id']
         let title = data[i]['title']
@@ -30,7 +33,7 @@ async function article_list() {
                             <td>${like}</td>
                             <td>${views}</td>
                         </tr>`
-        const article_list = document.getElementById('article_list')
+                        
         article_list.insertAdjacentHTML('beforeend', article)
     }
 
@@ -73,7 +76,7 @@ async function hobby_list() {
     const data = await response.json()
 
     for (let i = 0; i < data.length; i++) {
-        const hobby = `<button type="button" class="hobby" onclick="select_article_list(${data[i]['id']})">${data[i]['category']}</button>`;
+        const hobby = `<button type="button" class="hobby" onclick="select_article_list(${data[i]['id']}, '')">${data[i]['category']}</button>`;
 
         hobbys = document.getElementById("hobbys")
         hobbys.insertAdjacentHTML("beforeend", hobby);
@@ -81,8 +84,14 @@ async function hobby_list() {
 }
 
 // 선택한 카테고리의 게시글 목록
-async function select_article_list(category_id) {
-    const response = await get_select_articles(category_id)
+async function select_article_list(category_id, sort) {
+    const sort_btn = document.getElementById('sort_btn')
+    temp_html = `<span class="sort" id="latest" onclick="select_article_list(${category_id}, 'latest')">최신순</span>
+                <span class="sort" id="like" onclick="select_article_list(${category_id}, 'like')">인기순</span>`
+    sort_btn.innerHTML = ''
+    sort_btn.insertAdjacentHTML('beforeend', temp_html)
+    
+    const response = await get_select_articles(category_id, sort)
     const response_json = await response.json()
     const data = response_json['results']
 

--- a/templates/main/community.html
+++ b/templates/main/community.html
@@ -34,8 +34,10 @@
           <span class="menu" onclick="window.location.href='../main/workshop.html'">Workshop</span>
           <span class="select_menu" onclick="window.location.href='../main/community.html'">Community</span>
           <span style="float: right; margin: auto;">
-            <span class="sort">최신순</span>
-            <span class="sort">인기순</span>
+            <span id="sort_btn">
+              <span class="sort" id="latest" onclick="article_list('latest', '')">최신순</span>
+              <span class="sort" id="like" onclick="article_list('like', '')">인기순</span>  
+            </span>
           </span>
         </div>
         <div class="hobbys" id="hobbys"></div>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- sort-> develop
### 변경 사항
- 커뮤니티 페이지 최신순/인기순 버튼 클릭 시 정렬 기준대로 정렬되도록 기능 업데이트
- 특정 카테고리 선택 시 출력되는 해당 카테고리의 게시글에서도 최신순/인기순 버튼 클릭 시 정렬됨
### 테스트 결과
- 사진 설명
![image](https://user-images.githubusercontent.com/112394164/208111905-f1f52d2f-33a3-4dc6-ae61-aa40da76df37.png)
